### PR TITLE
Implemented exporting/importing plugin settings as JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@types/ws": "^8.5.10",
+        "ajv": "^8.17.1",
         "axios": "^1.6.7",
         "pdfmake": "^0.2.20",
         "vscode-languageclient": "^9.0.1",
@@ -142,6 +143,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -152,6 +170,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -772,16 +797,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1633,6 +1657,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1669,6 +1710,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1764,7 +1812,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1797,6 +1844,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2538,10 +2601,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3378,6 +3440,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -39,11 +39,6 @@
         "command": "codestyletest.exportSettings",
         "title": "Export settings to JSON file",
         "category": "Code Style and Smells"
-      },
-      {
-        "command": "codestyletest.importSettings",
-        "title": "Import settings from JSON file",
-        "category": "Code Style and Smells"
       }
     ],
     "configuration": [
@@ -271,9 +266,6 @@
       "view/title": [
         {
           "command": "codestyletest.exportSettings"
-        },
-        {
-          "command": "codestyletest.importSettings"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,16 @@
         "command": "codestyletest.analyze",
         "title": "Analyze Java code smells",
         "category": "Code Style and Smells"
+      },
+      {
+        "command": "codestyletest.exportSettings",
+        "title": "Export settings to JSON file",
+        "category": "Code Style and Smells"
+      },
+      {
+        "command": "codestyletest.importSettings",
+        "title": "Import settings from JSON file",
+        "category": "Code Style and Smells"
       }
     ],
     "configuration": [
@@ -256,7 +266,17 @@
         "view": "customView",
         "contents": "[Format Java code](command:codestyletest.format)\n[Analyze Java code smells](command:codestyletest.analyze)"
       }
-    ]
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "codestyletest.exportSettings"
+        },
+        {
+          "command": "codestyletest.importSettings"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -280,6 +300,7 @@
   },
   "dependencies": {
     "@types/ws": "^8.5.10",
+    "ajv": "^8.17.1",
     "axios": "^1.6.7",
     "pdfmake": "^0.2.20",
     "vscode-languageclient": "^9.0.1",

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -1,0 +1,133 @@
+{
+  "type": "object",
+  "properties": {
+    "braceStyle": {
+      "type": "string",
+      "enum": ["break", "attach"],
+      "default": "break"
+    },
+    "spaceAroundOperators": {
+      "type": "boolean",
+      "default": true
+    },
+    "maxLineLength": {
+      "type": "number",
+      "default": 100
+    },
+    "modifierOrder": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["public", "protected", "private", "static", "abstract", "final"]
+          },
+          "uniqueItems": true,
+          "default": ["public", "protected", "private", "abstract", "static", "final"]
+        },
+        "method": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["public", "protected", "private", "static", "abstract", "final", "synchronized", "transient", "volatile"]
+          },
+          "uniqueItems": true,
+          "default": ["public", "protected", "private", "abstract", "static", "final", "synchronized"]
+        }
+      },
+      "required": ["class", "method"],
+      "additionalProperties": false
+    },
+    "namingConventions": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "type": "string",
+          "default": "pascalcase"
+        },
+        "method": {
+          "type": "string",
+          "default": "camelcase"
+        },
+        "variable": {
+          "type": "string",
+          "default": "camelcase"
+        },
+        "constant": {
+          "type": "string",
+          "default": "uppercase"
+        },
+        "parameter": {
+          "type": "string",
+          "default": "camelcase"
+        }
+      },
+      "required": ["class", "method", "variable", "constant", "parameter"],
+      "additionalProperties": false
+    },
+    "imports": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "string",
+          "enum": ["sort", "preserve"],
+          "default": "preserve"
+        },
+        "merge": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": ["order", "merge"],
+      "additionalProperties": false
+    },
+    "indents": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "number",
+          "default": 4
+        },
+        "type": {
+          "type": "string",
+          "enum": ["spaces", "tabs"],
+          "default": "spaces"
+        },
+        "switchCaseLabels": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": ["size", "type", "switchCaseLabels"],
+      "additionalProperties": false
+    },
+    "aligns": {
+      "type": "object",
+      "properties": {
+        "afterOpenBracket": {
+          "type": "string",
+          "enum": ["none", "align", "dont_align", "always_break", "block_indent"],
+          "default": "none"
+        },
+        "parametersBeforeAlignment": {
+          "type": "number",
+          "default": 2
+        }
+      },
+      "required": ["afterOpenBracket", "parametersBeforeAlignment"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "braceStyle",
+    "spaceAroundOperators",
+    "maxLineLength",
+    "modifierOrder",
+    "namingConventions",
+    "imports",
+    "indents",
+    "aligns"
+  ],
+  "additionalProperties": false
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ const WS_URL = "ws://localhost:8000";
 const CONNECTION_TIMEOUT = 5000;
 
 const ajv = new Ajv();
-const configFileName = "assistantConfig.json";
+const configFileName = ".assistantConfig";
 
 const activeWebSockets: Map<string, WebSocket> = new Map();
 let progressBarPromise: Thenable<void> | undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -499,8 +499,7 @@ function openPDF(filePath: string) {
 
 async function exportSettings() {
     const settings = vscode.workspace.getConfiguration("codestyletest");
-    console.log(JSON.stringify(settings, null, 4))
-    
+
     const uri = await vscode.window.showSaveDialog({
         filters: { 'JSON': ['json'] },
         defaultUri: vscode.Uri.file(path.join(
@@ -511,8 +510,14 @@ async function exportSettings() {
     });
 
     if (uri) {
-        fs.writeFileSync(uri.fsPath, JSON.stringify(settings, null, 4));
-        vscode.window.showInformationMessage('Settings exported!');
+        try {
+            fs.writeFileSync(uri.fsPath, JSON.stringify(settings, null, 4));
+            vscode.window.showInformationMessage('Settings exported!');
+        } catch (error) {
+            vscode.window.showErrorMessage(
+                `Failed to export settings: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
     } else {
         vscode.window.showErrorMessage('No output path is selected.');
     }


### PR DESCRIPTION
The following PR includes:
- The ability to import and export the plugin's settings as a JSON file for easy sharing.
- Validation against a schema file
- Running the commands from both the command palette and the plugin's tab
Potential future work:
- Might need to rename references (Changed namespace in PR#11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to export current code style settings to a JSON file.
  - Added the ability to import and validate code style settings from a JSON file.
  - Export command is accessible directly from the UI view title menu.
  - Introduced a detailed schema to validate and autocomplete code style configuration files.

- **Chores**
  - Updated dependencies to include JSON schema validation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->