### PR TITLE
Autocompletion implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
         "category": "Java Code Assistant"
       },
       {
-        "command": "javacodeassistant.getReferences",
-        "title": "Get Java references",
+        "command": "javacodeassistant.generateCompletion",
+        "title": "Generate completion",
         "category": "Java Code Assistant"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "javacodeassistant",
-  "displayName": "javacodeassistant",
-  "description": "",
+  "displayName": "CodeGator",
+  "description": "Java Code Assistant for Visual Studio Code",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.98.0"
   },
   "categories": [
     "Other"
+  ],
+  "extensionDependencies": [
+    "redhat.java"
   ],
   "activationEvents": [],
   "main": "./out/extension.js",
@@ -43,6 +46,11 @@
       {
         "command": "javacodeassistant.exportSettings",
         "title": "Export settings to JSON file",
+        "category": "Java Code Assistant"
+      },
+      {
+        "command": "javacodeassistant.getReferences",
+        "title": "Get Java references",
         "category": "Java Code Assistant"
       }
     ],
@@ -247,7 +255,7 @@
       "activitybar": [
         {
           "id": "extensionTab",
-          "title": "Java Code Assistant",
+          "title": "CodeGator",
           "icon": "resources/javacodeassistant.svg"
         }
       ]
@@ -256,7 +264,7 @@
       "extensionTab": [
         {
           "id": "customView",
-          "name": "Java Code Assistant",
+          "name": "CodeGator",
           "icon": "resources/javacodeassistant.svg"
         }
       ]

--- a/src/InlineCompletionProvider.ts
+++ b/src/InlineCompletionProvider.ts
@@ -1,0 +1,199 @@
+import * as vscode from 'vscode';
+import { getCurrentContext, getMethodtoCursor, SimpleClassAnalysis } from "./classAnalysis";
+import { SERVER_URL } from './extension';
+import axios from 'axios';
+
+interface CompletionResponse {
+    completion: string;
+}
+
+interface CacheEntry {
+    completion: string;
+    timestamp: number;
+}
+
+export class InlineCompletionProvider implements vscode.InlineCompletionItemProvider {
+    private debounceTimer: NodeJS.Timeout | null = null;
+    private readonly debounceDelay = 300; // 300ms delay
+    private cache = new Map<string, CacheEntry>();
+    private readonly cacheTimeout = 5 * 60 * 1000; // 5 minutes
+    private readonly maxCacheSize = 100; // Maximum number of cached entries
+
+    async provideInlineCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.InlineCompletionContext,
+        token: vscode.CancellationToken
+    ): Promise<vscode.InlineCompletionItem[] | undefined> {
+        // Clear existing timer
+        if (this.debounceTimer) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = null;
+        }
+
+        // Return a promise that resolves after the debounce delay
+        return new Promise((resolve) => {
+            this.debounceTimer = setTimeout(async () => {
+                try {
+                    const result = await this.getCompletionItems(document, position, context, token);
+                    resolve(result);
+                } catch (error) {
+                    console.error('Error in debounced completion:', error);
+                    resolve([]);
+                }
+            }, this.debounceDelay);
+        });
+    }
+
+    private async getCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.InlineCompletionContext,
+        token: vscode.CancellationToken
+    ): Promise<vscode.InlineCompletionItem[] | undefined> {
+        // Check if request was cancelled during debounce
+        if (token.isCancellationRequested) {
+            return [];
+        }
+
+        // Get your existing context
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return [];
+        }
+        if (document.languageId !== 'java') {
+            return [];
+        }
+
+        const methodChunk = await getMethodtoCursor(editor, position);
+        const classContext = await getCurrentContext(document);
+
+        if (!methodChunk || !classContext) {
+            return [];
+        }
+
+        // Check cancellation again before API call
+        if (token.isCancellationRequested) {
+            return [];
+        }
+
+        // Try to get from cache first
+        const cacheKey = this.generateCacheKey(methodChunk, classContext);
+        let completion = this.getFromCache(cacheKey);
+        
+        if (!completion) {
+            // Call your API if not in cache
+            completion = await this.getCompletionFromAPI(methodChunk, classContext, token);
+            
+            // Cache the result if successful
+            if (completion) {
+                this.addToCache(cacheKey, completion);
+            }
+        }
+
+        if (!completion || token.isCancellationRequested) {
+            return [];
+        }
+
+        // Create inline completion item
+        const item = new vscode.InlineCompletionItem(
+            completion,
+            new vscode.Range(position, position)
+        );
+
+        return [item];
+    }
+
+    private async getCompletionFromAPI(code: string, context: SimpleClassAnalysis, token: vscode.CancellationToken): Promise<string | null> {
+        try {
+            // Create axios request with cancellation support
+            const source = axios.CancelToken.source();
+            
+            // Cancel axios request if VSCode cancellation is requested
+            token.onCancellationRequested(() => {
+                source.cancel('Request cancelled by VSCode');
+            });
+
+            const response = await axios.post(`${SERVER_URL}/autocomplete`, {
+                code: code,
+                context: context
+            }, {
+                cancelToken: source.token,
+                timeout: 5000 // 5 second timeout
+            });
+
+            const data = response.data as CompletionResponse;
+
+            // Additional text processing can be done here if needed
+
+            return data.completion;
+        } catch (error) {
+            if (axios.isCancel(error)) {
+                console.log('Request cancelled:', error.message);
+            } else {
+                console.error('API call failed:', error);
+            }
+            return null;
+        }
+    }
+
+    private generateCacheKey(code: string, context: SimpleClassAnalysis): string {
+        // Create a hash-like key from the code and relevant context
+        // You might want to include only certain parts of context to avoid over-specific keys
+        const contextKey = JSON.stringify({
+            className: context.className,
+            methods: context.methods?.slice(0, 5) // Just method names
+        });
+        
+        return `${code.trim()}||${contextKey}`;
+    }
+
+    private getFromCache(key: string): string | null {
+        const entry = this.cache.get(key);
+        
+        if (!entry) {
+            return null;
+        }
+        
+        // Check if cache entry has expired
+        if (Date.now() - entry.timestamp > this.cacheTimeout) {
+            this.cache.delete(key);
+            return null;
+        }
+        
+        return entry.completion;
+    }
+
+    private addToCache(key: string, completion: string): void {
+        // Implement LRU-like behavior by removing oldest entries when cache is full
+        if (this.cache.size >= this.maxCacheSize) {
+            const firstKey = this.cache.keys().next().value;
+            if (typeof firstKey === 'string') {
+                this.cache.delete(firstKey);
+            }
+        }
+        
+        this.cache.set(key, {
+            completion,
+            timestamp: Date.now()
+        });
+    }
+
+    private clearExpiredCache(): void {
+        const now = Date.now();
+        for (const [key, entry] of this.cache.entries()) {
+            if (now - entry.timestamp > this.cacheTimeout) {
+                this.cache.delete(key);
+            }
+        }
+    }
+
+    // Clean up timer and cache when provider is disposed
+    dispose() {
+        if (this.debounceTimer) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = null;
+        }
+        this.cache.clear();
+    }
+}

--- a/src/classAnalysis.ts
+++ b/src/classAnalysis.ts
@@ -1,0 +1,355 @@
+import * as vscode from 'vscode';
+
+interface ClassMember {
+    name: string;
+    kind: 'method' | 'field';
+    visibility: 'public' | 'private' | 'protected' | 'package';
+    static: boolean;
+    type: string;
+    signature?: string; // For methods
+    inherited?: boolean;
+    source?: string; // Class where the member is defined
+}
+
+interface ClassAnalysis {
+    className: string;
+    methods: ClassMember[];
+    fields: ClassMember[];
+    compositionMembers: ClassMember[]; // Methods/fields from composed objects
+    inheritedMembers: ClassMember[]; // Methods/fields from parent classes
+    superClass?: string;
+    interfaces: string[];
+}
+
+export async function analyzeJavaClass(document: vscode.TextDocument): Promise<ClassAnalysis | null> {
+    try {
+        // Get document symbols
+        const documentSymbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+            'vscode.executeDocumentSymbolProvider',
+            document.uri
+        );
+
+        if (!documentSymbols) {
+            return null;
+        }
+
+        // Find the first class symbol (assuming single class per file)
+        const classSymbol = documentSymbols.find(symbol => symbol.kind === vscode.SymbolKind.Class);
+        if (!classSymbol) {
+            return null;
+        }
+
+        const analysis: ClassAnalysis = {
+            className: classSymbol.name,
+            methods: [],
+            fields: [],
+            compositionMembers: [],
+            inheritedMembers: [],
+            interfaces: []
+        };
+
+        // Get type hierarchy information using the class symbol's position
+        const typeHierarchy = await getTypeHierarchy(document.uri, classSymbol.selectionRange.start);
+        
+        // Analyze direct members of the class
+        await analyzeDirectMembers(classSymbol, analysis, document);
+        
+        // Analyze inherited members from parent classes
+        if (typeHierarchy) {
+            await analyzeInheritedMembers(typeHierarchy, analysis);
+        }
+        
+        // Analyze composition members (fields that are objects with their own methods)
+        await analyzeCompositionMembers(document.uri, classSymbol, analysis);
+
+        return analysis;
+    } catch (error) {
+        console.error('Error analyzing Java class:', error);
+        return null;
+    }
+}
+
+async function getTypeHierarchy(uri: vscode.Uri, position: vscode.Position): Promise<vscode.TypeHierarchyItem[] | null> {
+    try {
+        const items = await vscode.commands.executeCommand<vscode.TypeHierarchyItem[]>(
+            'vscode.prepareTypeHierarchy',
+            uri,
+            position
+        );
+
+        if (items && items.length > 0) {
+            // Get supertypes (parent classes and interfaces)
+            const supertypes = await vscode.commands.executeCommand<vscode.TypeHierarchyItem[]>(
+                'vscode.provideTypeHierarchySupertypes',
+                items[0]
+            );
+            return supertypes;
+        }
+        return null;
+    } catch (error) {
+        console.error('Error getting type hierarchy:', error);
+        return null;
+    }
+}
+
+async function analyzeDirectMembers(classSymbol: vscode.DocumentSymbol, analysis: ClassAnalysis, document: vscode.TextDocument): Promise<void> {
+    for (const child of classSymbol.children) {
+        // Get hover information for better type and modifier details
+        const hoverInfo = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            document.uri,
+            child.selectionRange.start
+        );
+
+        const hoverText = hoverInfo && hoverInfo.length > 0 
+            ? extractTextFromHover(hoverInfo[0]) 
+            : '';
+
+        const member: ClassMember = {
+            name: child.name,
+            kind: child.kind === vscode.SymbolKind.Method || child.kind === vscode.SymbolKind.Constructor ? 'method' : 'field',
+            visibility: parseVisibility(hoverText) || parseVisibilityFromContext(child, document),
+            static: isStatic(hoverText) || await isStaticFromContext(child, document),
+            type: parseType(hoverText) || await getTypeFromContext(child, document),
+            inherited: false,
+            source: analysis.className
+        };
+
+        if (member.kind === 'method') {
+            member.signature = hoverText || child.detail || '';
+            analysis.methods.push(member);
+        } else if (child.kind === vscode.SymbolKind.Field || child.kind === vscode.SymbolKind.Property) {
+            analysis.fields.push(member);
+        }
+    }
+}
+
+async function analyzeInheritedMembers(
+    supertypes: vscode.TypeHierarchyItem[],
+    analysis: ClassAnalysis
+): Promise<void> {
+    for (const supertype of supertypes) {
+        if (supertype.kind === vscode.SymbolKind.Class) {
+            analysis.superClass = supertype.name;
+        } else if (supertype.kind === vscode.SymbolKind.Interface) {
+            analysis.interfaces.push(supertype.name);
+        }
+
+        // Get members from the supertype
+        const supertypeSymbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+            'vscode.executeDocumentSymbolProvider',
+            supertype.uri
+        );
+
+        if (supertypeSymbols) {
+            const supertypeClass = supertypeSymbols.find(s => s.name === supertype.name);
+            if (supertypeClass) {
+                for (const child of supertypeClass.children) {
+                    const visibility = parseVisibilityFromContext(child, await vscode.workspace.openTextDocument(supertype.uri));
+                    
+                    // Only include public and protected members (accessible to subclasses)
+                    if (visibility === 'public' || visibility === 'protected') {
+                        const member: ClassMember = {
+                            name: child.name,
+                            kind: child.kind === vscode.SymbolKind.Method || child.kind === vscode.SymbolKind.Constructor ? 'method' : 'field',
+                            visibility,
+                            static: await isStaticFromContext(child, await vscode.workspace.openTextDocument(supertype.uri)),
+                            type: await getTypeFromContext(child, await vscode.workspace.openTextDocument(supertype.uri)),
+                            inherited: true,
+                            source: supertype.name
+                        };
+
+                        if (member.kind === 'method') {
+                            member.signature = child.detail || '';
+                        }
+
+                        analysis.inheritedMembers.push(member);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async function analyzeCompositionMembers(
+    uri: vscode.Uri,
+    classSymbol: vscode.DocumentSymbol,
+    analysis: ClassAnalysis
+): Promise<void> {
+    const document = await vscode.workspace.openTextDocument(uri);
+    
+    // Find field declarations that are object types
+    for (const field of classSymbol.children) {
+        if (field.kind === vscode.SymbolKind.Field || field.kind === vscode.SymbolKind.Property) {
+            // Use hover provider like in analyzeDirectMembers
+            const hoverInfo = await vscode.commands.executeCommand<vscode.Hover[]>(
+                'vscode.executeHoverProvider',
+                uri,
+                field.selectionRange.start
+            );
+
+            const hoverText = hoverInfo && hoverInfo.length > 0 
+                ? extractTextFromHover(hoverInfo[0]) 
+                : '';
+
+            const fieldType = parseType(hoverText) || await getTypeFromContext(field, document);
+            
+            // Skip primitive types and common Java types
+            if (isPrimitiveOrCommonType(fieldType)) {
+                continue;
+            }
+
+            console.log(`Field: ${field.name}, HoverText: "${hoverText}", ExtractedType: "${fieldType}"`);
+
+            // Try to find the definition of the field type
+            const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+                'vscode.executeDefinitionProvider',
+                uri,
+                field.range.start
+            );
+
+            if (definitions && definitions.length > 0) {
+                const typeDefinition = definitions[0];
+                const typeSymbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                    'vscode.executeDocumentSymbolProvider',
+                    typeDefinition.uri
+                );
+
+                if (typeSymbols) {
+                    const typeClass = typeSymbols.find(s => s.name === fieldType);
+                    if (typeClass) {
+                        for (const member of typeClass.children) {
+                            const visibility = parseVisibilityFromContext(member, await vscode.workspace.openTextDocument(typeDefinition.uri));
+                            
+                            // Only include public members for composition
+                            if (visibility === 'public') {
+                                const compositionMember: ClassMember = {
+                                    name: `${field.name}.${member.name}`,
+                                    kind: member.kind === vscode.SymbolKind.Method || member.kind === vscode.SymbolKind.Constructor ? 'method' : 'field',
+                                    visibility,
+                                    static: await isStaticFromContext(member, await vscode.workspace.openTextDocument(typeDefinition.uri)),
+                                    type: await getTypeFromContext(member, await vscode.workspace.openTextDocument(typeDefinition.uri)),
+                                    inherited: false,
+                                    source: `${fieldType} (via ${field.name})`
+                                };
+
+                                if (compositionMember.kind === 'method') {
+                                    compositionMember.signature = member.detail || '';
+                                }
+
+                                analysis.compositionMembers.push(compositionMember);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Helper functions for parsing symbol information
+function extractTextFromHover(hover: vscode.Hover): string {
+    if (!hover.contents || hover.contents.length === 0) {
+        return '';
+    }
+
+    let text = '';
+    for (const content of hover.contents) {
+        if (typeof content === 'string') {
+            text += content;
+        } else if (content instanceof vscode.MarkdownString) {
+            text += content.value;
+        } else if ('language' in content && 'value' in content) {
+            // It's a MarkedString with language and value
+            text += content.value;
+        }
+    }
+    
+    // Clean up markdown formatting
+    return text.replace(/```java\n?|```\n?/g, '').replace(/\*\*/g, '').trim();
+}
+
+function parseVisibility(hoverText: string): 'public' | 'private' | 'protected' | 'package' | null {
+    if (!hoverText) return null;
+    if (hoverText.includes('private')) return 'private';
+    if (hoverText.includes('protected')) return 'protected';
+    if (hoverText.includes('public')) return 'public';
+    return null;
+}
+
+function parseVisibilityFromContext(symbol: vscode.DocumentSymbol, document: vscode.TextDocument): 'public' | 'private' | 'protected' | 'package' {
+    // Get the text of the line where the symbol is defined
+    const line = document.lineAt(symbol.range.start.line);
+    const lineText = line.text;
+    
+    if (lineText.includes('private')) return 'private';
+    if (lineText.includes('protected')) return 'protected';
+    if (lineText.includes('public')) return 'public';
+    return 'package';
+}
+
+function isStatic(hoverText: string): boolean {
+    return hoverText.includes('static');
+}
+
+async function isStaticFromContext(symbol: vscode.DocumentSymbol, document: vscode.TextDocument): Promise<boolean> {
+    // Get the text of the line where the symbol is defined
+    const line = document.lineAt(symbol.range.start.line);
+    const lineText = line.text;
+    
+    return lineText.includes('static');
+}
+
+function parseType(hoverText: string): string | null {
+    if (!hoverText) return null;
+    
+    // Try to extract type from hover text (which often contains full signature)
+    // Look for patterns like "public static String methodName" or "private int fieldName"
+    const typeMatch = hoverText.match(/(?:public|private|protected)?\s*(?:static)?\s*(?:final)?\s*([A-Za-z_$][A-Za-z0-9_$<>,\[\]\s]*?)\s+[A-Za-z_$]/);
+    if (typeMatch && typeMatch[1]) {
+        return typeMatch[1].trim();
+    }
+    
+    return null;
+}
+
+async function getTypeFromContext(symbol: vscode.DocumentSymbol, document: vscode.TextDocument): Promise<string> {
+    // For fields, try to extract type from the line
+    if (symbol.kind === vscode.SymbolKind.Field || symbol.kind === vscode.SymbolKind.Property) {
+        const line = document.lineAt(symbol.range.start.line);
+        const lineText = line.text.trim();
+        
+        // Simple regex to extract type from field declaration
+        // Matches patterns like: private String fieldName, public static int count, etc.
+        const fieldMatch = lineText.match(/(?:public|private|protected)?\s*(?:static)?\s*(?:final)?\s*([A-Za-z_$][A-Za-z0-9_$<>,\[\]\s]*?)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*[=;]/);
+        if (fieldMatch && fieldMatch[1]) {
+            return fieldMatch[1].trim();
+        }
+    }
+    
+    // For methods, try to extract return type
+    if (symbol.kind === vscode.SymbolKind.Method) {
+        const line = document.lineAt(symbol.range.start.line);
+        const lineText = line.text.trim();
+        
+        // Simple regex to extract return type from method declaration
+        const methodMatch = lineText.match(/(?:public|private|protected)?\s*(?:static)?\s*(?:final)?\s*([A-Za-z_$][A-Za-z0-9_$<>,\[\]\s]*?)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*\(/);
+        if (methodMatch && methodMatch[1]) {
+            return methodMatch[1].trim();
+        }
+    }
+    
+    return 'unknown';
+}
+
+function isPrimitiveOrCommonType(type: string): boolean {
+    const primitiveAndCommonTypes = [
+        'int', 'long', 'double', 'float', 'boolean', 'char', 'byte', 'short',
+        'Integer', 'Long', 'Double', 'Float', 'Boolean', 'Character', 'Byte', 'Short',
+        'String', 'Object', 'List', 'ArrayList', 'Map', 'HashMap', 'Set', 'HashSet'
+    ];
+    
+    return primitiveAndCommonTypes.some(primitive => 
+        type === primitive || type.startsWith(primitive + '<')
+    );
+}

--- a/src/classAnalysis.ts
+++ b/src/classAnalysis.ts
@@ -21,7 +21,7 @@ interface ClassAnalysis {
     interfaces: string[];
 }
 
-interface SimpleClassAnalysis {
+export interface SimpleClassAnalysis {
     className: string;
     methods: string[];
     fields: string[];
@@ -84,7 +84,7 @@ function formatMember(member: ClassMember): string {
     return `${visibility}${staticModifier}${member.type} ${member.name}`;
 }
 
-export async function getMethodtoCursor(editor: vscode.TextEditor, cursorPos: vscode.Position): Promise<String | null> {
+export async function getMethodtoCursor(editor: vscode.TextEditor, cursorPos: vscode.Position): Promise<string | null> {
     const document = editor.document;
     const classSymbol = await getClassSymbol(document);
     if (!classSymbol) {

--- a/src/classAnalysis.ts
+++ b/src/classAnalysis.ts
@@ -199,13 +199,13 @@ async function analyzeCompositionMembers(
                 continue;
             }
 
-            console.log(`Field: ${field.name}, HoverText: "${hoverText}", ExtractedType: "${fieldType}"`);
+            const typePosition = findTypePositionInField(document, field, fieldType);
 
             // Try to find the definition of the field type
             const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
                 'vscode.executeDefinitionProvider',
                 uri,
-                field.range.start
+                typePosition
             );
 
             if (definitions && definitions.length > 0) {
@@ -214,6 +214,8 @@ async function analyzeCompositionMembers(
                     'vscode.executeDocumentSymbolProvider',
                     typeDefinition.uri
                 );
+
+                console.log(typeSymbols);
 
                 if (typeSymbols) {
                     const typeClass = typeSymbols.find(s => s.name === fieldType);
@@ -245,6 +247,19 @@ async function analyzeCompositionMembers(
             }
         }
     }
+}
+
+function findTypePositionInField(document: vscode.TextDocument, field: vscode.DocumentSymbol, typeName: string): vscode.Position | null {
+    const line = document.lineAt(field.range.start.line);
+    const lineText = line.text;
+    
+    // Find the position of the type name in the line
+    const typeIndex = lineText.indexOf(typeName);
+    if (typeIndex !== -1) {
+        return new vscode.Position(field.range.start.line, typeIndex);
+    }
+    
+    return null;
 }
 
 // Helper functions for parsing symbol information

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import axios from 'axios';
 import WebSocket from 'ws';
 import { pdfGenerator } from './pdfGenerator';
-import { analyzeJavaClass } from "./classAnalysis";
+import { analyzeJavaClass, getClassSymbol, getMethodtoCursor } from "./classAnalysis";
 import Ajv from 'ajv';
 
 interface FormatResponse {
@@ -170,7 +170,7 @@ export async function activate(context: vscode.ExtensionContext) : Promise<void>
                 }
                 const uri = document.uri;
 
-                await getClassStructure(uri);
+                await getCurrentMethod(uri);
             }
         )
     );
@@ -676,4 +676,16 @@ async function getClassStructure(uri: vscode.Uri) {
     } else {
         vscode.window.showErrorMessage('Could not analyze the current Java class');
     }
+}
+
+async function getCurrentMethod(uri: vscode.Uri) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'java') {
+        vscode.window.showErrorMessage('Please open a Java file');
+        return;
+    }
+
+    const cursorPos = editor.selection.active;
+    
+    const method = await getMethodtoCursor(editor, cursorPos);
 }

--- a/src/server/AutoComplete/AutoComplete.py
+++ b/src/server/AutoComplete/AutoComplete.py
@@ -49,6 +49,7 @@ class AutoComplete:
         # Remove prompt from output
         if outputs:
             outputs = outputs[len(prompt):].strip()
+            outputs = outputs[len(code):].strip()  # Remove the original code part
 
         # return outputs
         return outputs if outputs else ""

--- a/src/server/AutoComplete/AutoComplete.py
+++ b/src/server/AutoComplete/AutoComplete.py
@@ -1,0 +1,54 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+checkpoint = "bigcode/santacoder"
+device = "cuda"
+
+class AutoComplete:
+    def __init__(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+        self.model = AutoModelForCausalLM.from_pretrained(checkpoint, trust_remote_code=True).to(device)
+    
+    def create_prompt(self, context):
+        # Create prompt that includes the fields from context: className, methods, fields, compositionMembers, inheritedMembers, interfaces as a java comment
+        prompt = "// Class: {}\n".format(context.get("className", ""))
+        # Put methods in a comment, single line, separated by commas
+        methods = context.get("methods", [])
+        if methods:
+            prompt += "// Available Methods: {}\n".format(", ".join(methods))
+        # Put fields in a comment, single line, separated by commas
+        fields = context.get("fields", [])
+        if fields:
+            prompt += "// Available Fields: {}\n".format(", ".join(fields))
+        # Put compositionMembers in a comment, single line, separated by commas
+        composition_members = context.get("compositionMembers", [])
+        if composition_members:
+            prompt += "// Available Composition Members: {}\n".format(", ".join(composition_members))
+        # Put inheritedMembers in a comment, single line, separated by commas
+        inherited_members = context.get("inheritedMembers", [])
+        if inherited_members:
+            prompt += "// Available Inherited Members: {}\n".format(", ".join(inherited_members))
+        # Put interfaces in a comment, single line, separated by commas
+        interfaces = context.get("interfaces", [])
+        if interfaces:
+            prompt += "// Available Interfaces: {}\n".format(", ".join(interfaces))
+
+        return prompt
+        
+    def predict_completion(self, code, context):
+        prompt = self.create_prompt(context)
+        full_code = prompt + code
+
+        inputs = self.tokenizer(full_code, return_tensors="pt").to(self.model.device)
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=32,
+            pad_token_id=self.tokenizer.eos_token_id, use_cache=True, do_sample=True, temperature=0.8, top_k=50, top_p=0.95
+        )
+        outputs = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+        # Remove prompt from output
+        if outputs:
+            outputs = outputs[len(prompt):].strip()
+
+        # return outputs
+        return outputs if outputs else ""

--- a/src/server/webserver.py
+++ b/src/server/webserver.py
@@ -143,7 +143,8 @@ async def refine_code(request: RefinementRequest):
 async def autocomplete_code(request: CompletionRequest):
     try:
         completed_code = autocomplete_instance.predict_completion(request.code, request.context)
-        logger.info(f"Predicted output: {completed_code}")
+        logger.info(f"Autocomplete prediction:")
+        logger.info(f"{completed_code}")
         return {"completion": completed_code}
     except Exception as e:
         logger.error(f"Completion error: {e}")


### PR DESCRIPTION
This was a delightful (read: sarcasm and irony) foray into adding the inline completions with vibe coding. 
- Implemented a model runner, initialized in the backend startup (which explains why the startup might take a bit)
- Added inline completions with the VSCode API which turned out to be relatively nice, thankfully.
- Added a caching system that I'm 100% unsure of so please give it a try lmfao.
**NOTE:** Downgrade your transformers package to **v4.31.0** to work properly with SantaCoder (also that is 4GB so oops, sorry lol)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced inline code completion for Java files within Visual Studio Code.
  - Added a new command, "Generate completion," accessible via the command palette.
  - Enhanced Java class analysis for improved contextual code suggestions.
  - Added autocomplete support powered by an integrated backend model.

- **Chores**
  - Updated extension name and description to "CodeGator" and "Java Code Assistant for Visual Studio Code."
  - Added dependency on the Red Hat Java extension for improved Java support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->